### PR TITLE
Add before class and after class methods

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,9 @@ SYNOPSIS
           return $self;
       }
 
+      sub before_class {
+          # run once before any of the test methods in the class
+      }
       sub set_up {
           # provide fixture
       }
@@ -37,6 +40,9 @@ SYNOPSIS
       }
       sub test_bar {
           # test the bar feature
+      }
+      sub after_class {
+          # run once after all test methods in the class
       }
 
 DESCRIPTION

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Using as a replacement for Test::Unit:
         return $self;
     }
 
+    sub before_class {
+        # run once before any of the test methods in the class
+    }
     sub set_up {
         # provide fixture
     }
@@ -39,6 +42,9 @@ Using as a replacement for Test::Unit:
     }
     sub test_bar {
         # test the bar feature
+    }
+    sub after_class {
+        # run once after all test methods in the class
     }
 
 # DESCRIPTION
@@ -86,6 +92,16 @@ when the assertion is false.
 - new
 
 The default constructor which just bless an empty anonymous hash reference.
+
+- before\_class
+
+This method is called once and as late as possible, just before first test. It is empty
+method and can be overridden in derived class.
+
+- after\_class
+
+This method is called once after all test methods in the class. It is empty
+method and can be overridden in derived class.
 
 - set\_up
 
@@ -220,7 +236,7 @@ Called after test unit is passed.
 
 Called after running test suite.
 
-- start(TEST\_SUITE)
+- start(TEST\_SUITE | TEST\_SUITE\_OBJECT)
 
 Starts the test suite.
 

--- a/lib/Test/Unit/Lite.pm
+++ b/lib/Test/Unit/Lite.pm
@@ -28,6 +28,9 @@ Using as a replacement for Test::Unit:
       return $self;
   }
 
+  sub before_class {
+      # run once before any of the test methods in the class
+  }
   sub set_up {
       # provide fixture
   }
@@ -43,6 +46,9 @@ Using as a replacement for Test::Unit:
   }
   sub test_bar {
       # test the bar feature
+  }
+  sub after_class {
+     # run once after all test methods in the class
   }
 
 =head1 DESCRIPTION

--- a/lib/Test/Unit/Lite.pm
+++ b/lib/Test/Unit/Lite.pm
@@ -559,6 +559,10 @@ sub all_tests {
         return $_[0]->{units};
     }
 
+    sub suite {
+        return $_[0];
+    }
+
     sub add_test {
         my ($self, $unit) = @_;
 
@@ -754,11 +758,13 @@ sub all_tests {
 
         my $result = Test::Unit::Result->new;
 
-        # untaint $test
-        $test =~ /([A-Za-z0-9:-]*)/;
-        $test = $1;
-        eval "use $test;";
-        die if $@;
+        if ( not ref $test ) {
+            # untaint $test
+            $test =~ /([A-Za-z0-9:-]*)/;
+            $test = $1;
+            eval "use $test;";
+            die if $@;
+        }
 
         if ($test->isa('Test::Unit::TestSuite')) {
             $self->{suite} = $test->suite;

--- a/t/tlib/BadUnits/WithErrorOnAfterClass.pm
+++ b/t/tlib/BadUnits/WithErrorOnAfterClass.pm
@@ -1,0 +1,17 @@
+package BadUnits::WithErrorOnAfterClass;
+
+use strict;
+use warnings;
+
+use base 'Test::Unit::TestCase';
+
+sub test_unit_with_after_class_error {
+    my $self = shift;
+    $self->assert(1);
+}
+
+sub after_class {
+    die "Problem with after_class";
+}
+
+1;

--- a/t/tlib/BadUnits/WithErrorOnBeforeClass.pm
+++ b/t/tlib/BadUnits/WithErrorOnBeforeClass.pm
@@ -1,0 +1,17 @@
+package BadUnits::WithErrorOnBeforeClass;
+
+use strict;
+use warnings;
+
+use base 'Test::Unit::TestCase';
+
+sub before_class {
+    die "Problem with before_class";
+}
+
+sub test_unit_with_before_class_error {
+    my $self = shift;
+    $self->assert(1);
+}
+
+1;

--- a/t/tlib/BeforeClassAfterClassErrorTest.pm
+++ b/t/tlib/BeforeClassAfterClassErrorTest.pm
@@ -1,0 +1,43 @@
+package BeforeClassAfterClassErrorTest;
+
+use strict;
+use warnings;
+
+package BeforeClassAfterClassErrorTest::Null::Tie;
+
+sub TIEHANDLE {
+    bless {}, shift;
+}
+
+sub PRINT {
+}
+
+package BeforeClassAfterClassErrorTest;
+
+use base 'Test::Unit::TestCase';
+
+use Test::Unit::Lite;
+
+sub test_suite_with_error_on_before_class {
+    my $self = shift;
+    select select my $fh_null;
+    tie *$fh_null, 'BeforeClassAfterClassErrorTest::Null::Tie';
+    my $runner = Test::Unit::TestRunner->new($fh_null, $fh_null);
+    eval {
+        $runner->start('BadUnits::WithErrorOnBeforeClass');
+    };
+    $self->assert(qr/^Problem with before_class/s, "$@");
+}
+
+sub test_suite_with_error_on_after_class {
+    my $self = shift;
+    select select my $fh_null;
+    tie *$fh_null, 'BeforeClassAfterClassErrorTest::Null::Tie';
+    my $runner = Test::Unit::TestRunner->new($fh_null, $fh_null);
+    eval {
+        $runner->start('BadUnits::WithErrorOnAfterClass');
+    };
+    $self->assert(qr/^Problem with after_class/s, "$@");
+}
+
+1;

--- a/t/tlib/BeforeClassTest.pm
+++ b/t/tlib/BeforeClassTest.pm
@@ -1,0 +1,20 @@
+package BeforeClassTest;
+
+use strict;
+use warnings;
+
+use base 'Test::Unit::TestCase';
+
+my $assert_var;
+
+sub before_class {
+	my ($self) = @_;
+	$assert_var = 1;
+}
+
+sub test_before_class {
+	my ($self) = @_;
+	$self->assert($assert_var);
+}
+
+1;

--- a/t/tlib/TestWithTestSuiteInstanceTest.pm
+++ b/t/tlib/TestWithTestSuiteInstanceTest.pm
@@ -1,0 +1,40 @@
+package TestWithTestSuiteInstanceTest;
+
+use strict;
+use warnings;
+
+package TestWithTestSuiteInstanceTest::Null::Tie;
+
+sub TIEHANDLE {
+    bless {}, shift;
+}
+
+sub PRINT {
+}
+
+sub PRINTF {
+}
+
+package TestWithTestSuiteInstanceTest;
+
+use base 'Test::Unit::TestCase';
+
+use Test::Unit::Lite;
+
+sub test_init_test_runner_with_instance {
+    my ($self) = @_;
+
+    select select my $fh_null;
+    tie *$fh_null, 'TestWithTestSuiteInstanceTest::Null::Tie';
+    my $runner = Test::Unit::TestRunner->new($fh_null, $fh_null);
+    my $suite = Test::Unit::TestSuite->empty_new;
+
+    $runner->start($suite);
+
+    my $runner_suite = $runner->suite;
+
+    $self->assert(ref $runner_suite && $runner_suite->isa('Test::Unit::TestSuite'));
+    $self->assert("$suite" eq "$runner_suite", "$suite vs $runner_suite");
+}
+
+1;


### PR DESCRIPTION
We talked about this some time ago (ok too long ago :disappointed:).
This changeset adds `before_class` and `after_class` to align to JUnit capabilities (in some way). Also we allow to initiate Runner with suite instance, this helps build TestSuite with certain tests only. Everything is battle tested for quite long time :+1: 
